### PR TITLE
Add workaround to waitCatch for #14

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -246,7 +246,10 @@ wait = atomically . waitSTM
 --
 {-# INLINE waitCatch #-}
 waitCatch :: Async a -> IO (Either SomeException a)
-waitCatch = atomically . waitCatchSTM
+waitCatch = tryAgain . atomically . waitCatchSTM
+  where
+    -- See: https://github.com/simonmar/async/issues/14
+    tryAgain f = f `catch` \BlockedIndefinitelyOnSTM -> f
 
 -- | Check whether an 'Async' has completed yet.  If it has not
 -- completed yet, then the result is @Nothing@, otherwise the result

--- a/test/test-async.hs
+++ b/test/test-async.hs
@@ -29,6 +29,7 @@ tests = [
          testCase "async_cancel"       async_cancel
   , testCase "async_poll"        async_poll
   , testCase "async_poll2"       async_poll2
+  , testCase "withasync_waitCatch_blocked" withasync_waitCatch_blocked
  ]
 
 value = 42 :: Int
@@ -104,3 +105,13 @@ async_poll2 = do
   when (isNothing r) $ assertFailure ""
   r <- poll a   -- poll twice, just to check we don't deadlock
   when (isNothing r) $ assertFailure ""
+
+withasync_waitCatch_blocked :: Assertion
+withasync_waitCatch_blocked = do
+  r <- withAsync (newEmptyMVar >>= takeMVar) waitCatch
+  case r of
+    Left e ->
+        case fromException e of
+            Just BlockedIndefinitelyOnMVar -> return ()
+            Nothing -> assertFailure $ show e
+    Right () -> assertFailure ""


### PR DESCRIPTION
This uses the same technique I described in my enclosed-exceptions pull
request. I think it would be better to fix this in async itself, so that
other packages trying to use async for reliable exception handling get
the semantics they're looking for.

Pinging @sol @jcristovao
