### PR TITLE
Fix typo in documentation

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -92,7 +92,7 @@ module Control.Concurrent.Async (
     -- ** Spawning with automatic 'cancel'ation
     withAsync, withAsyncBound, withAsyncOn, withAsyncWithUnmask, withAsyncOnWithUnmask,
 
-    -- ** Quering 'Async's
+    -- ** Querying 'Async's
     wait, poll, waitCatch, cancel, cancelWith,
     asyncThreadId,
 


### PR DESCRIPTION
I noticed a small typo in one of the section titles in your (wonderful) async library.

`Quering 'Async's` should be `Querying 'Async's` (missing 'y').

Best,
Markus
