### PR TITLE
Change semantics of withAsync & double performance of race and concurrently

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -509,17 +509,26 @@ concurrently left right =
 --
 -- More concretely:
 --
--- * When @left@ terminates, whether normally or by raising an
---   exception, it wraps its result in the 'UniqueInterruptWithResult'
---   exception and throws that to the right thread.
+-- When @left@ terminates, whether normally or by raising an
+-- exception, it wraps its result in the 'UniqueInterruptWithResult'
+-- exception and throws that to the right thread.
 --
--- * When the right thread catches the 'UniqueInterruptWithResult'
---   exception it will either throw the contained exception or return
---   the left result normally.
+-- When the right thread catches the 'UniqueInterruptWithResult'
+-- exception it will either throw the contained exception or return
+-- the left result normally.
 --
--- * When @right@ terminates, whether normally or by raising an
---   exception, it throws an 'UniqueInterrupt' exception to the left
---   thread in order to stop that thread from doing any more work.
+-- When @right@ terminates normally or by a non-asynchronous exception
+-- it kills the left thread. When it terminates with an asynchronous
+-- exception the exception is thrown to the left thread.
+--
+-- When @right@ terminates it has to throw an exception to the left
+-- thread. However, the left thread will throw an exception back to
+-- the right thread when it receives one. We don't want the left
+-- thread to throw back an exception it just got from the right
+-- thread. To protect against this we set a boolean before the right
+-- thread throws an exception to the left thread. The left thread
+-- checks this boolean before it needs to throw an exception to the
+-- right thread.
 --
 -- Because calls to @race@ can be nested it's important that different
 -- 'UniqueInterrupt' or 'UniqueInterruptWithResult' exceptions are not

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -554,7 +554,7 @@ race left right = do
     let interruptLeft e = do
           writeIORef throwToRightRef False
           throwTo leftTid e
-    catch ((Right <$> restore right) <* interruptLeft ThreadKilled) $ \e ->
+    catch (Right <$> restore right <* interruptLeft ThreadKilled) $ \e ->
           case fromException e of
             Just (UniqueInterruptWithResult u' leftResult) | u == u'
               -> case leftResult of

--- a/test/test-async.hs
+++ b/test/test-async.hs
@@ -13,9 +13,7 @@ import Data.IORef
 import Control.Concurrent
 import Control.Monad
 import Data.Maybe
-#if MIN_VERSION_base(4,7,0)
 import System.Timeout
-#endif
 
 import Prelude hiding (catch)
 

--- a/test/test-async.hs
+++ b/test/test-async.hs
@@ -59,6 +59,10 @@ tests = [
     , testCase "left_terminates_by_asynchronous_exception_kills_right"
            race_left_terminates_by_asynchronous_exception_kills_right
     ]
+  , testGroup "concurrently" $
+    [ testCase "1" concurrently_1
+    , testCase "2" concurrently_2
+    ]
  ]
 
 value = 42 :: Int
@@ -268,3 +272,16 @@ race_left_terminates_by_asynchronous_exception_kills_right = do
                       return 'x')
 
   r @?= Left ThreadKilled
+
+concurrently_1 :: Assertion
+concurrently_1 = do
+  r <- concurrently (threadDelay 1000 >> return 1)
+                    (threadDelay 1000 >> return 'x')
+  r @?= (1, 'x')
+
+concurrently_2 :: Assertion
+concurrently_2 = do
+  void $ timeout 1000 $
+    concurrently (threadDelay 10000)
+                 (threadDelay 10000)
+  threadDelay 10000

--- a/test/test-async.hs
+++ b/test/test-async.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables,DeriveDataTypeable #-}
+{-# LANGUAGE CPP, ScopedTypeVariables, DeriveDataTypeable #-}
 module Main where
 
 import Test.Framework (defaultMain, testGroup)
@@ -9,9 +9,13 @@ import Test.HUnit
 import Control.Concurrent.Async
 import Control.Exception
 import Data.Typeable
+import Data.IORef
 import Control.Concurrent
 import Control.Monad
 import Data.Maybe
+#if MIN_VERSION_base(4,7,0)
+import System.Timeout
+#endif
 
 import Prelude hiding (catch)
 
@@ -23,13 +27,40 @@ tests = [
   , testCase "async_exwait"      async_exwait
   , testCase "async_exwaitCatch" async_exwaitCatch
   , testCase "withasync_waitCatch" withasync_waitCatch
-  , testCase "withasync_wait2"   withasync_wait2
+  , testCase "withasync_functionReturned_threadKilled"
+              withasync_functionReturned_threadKilled
+  , testCase "withasync_synchronousException_threadKilled"
+              withasync_synchronousException_threadKilled
+  , testCase "withasync_asynchronousException_rethrown"
+              withasync_asynchronousException_rethrown
+#if MIN_VERSION_base(4,7,0)
+  , testCase "withasync_timeoutException_rethrown"
+              withasync_timeoutException_rethrown
+#endif
   , testGroup "async_cancel_rep" $
       replicate 1000 $
          testCase "async_cancel"       async_cancel
   , testCase "async_poll"        async_poll
   , testCase "async_poll2"       async_poll2
   , testCase "withasync_waitCatch_blocked" withasync_waitCatch_blocked
+  , testGroup "race" $
+    [ testCase "right_terminate_normally"
+           race_right_terminate_normally
+    , testCase "left_terminate_normally"
+           race_left_terminate_normally
+    , testCase "right_terminate_by_synchronous_exception"
+           race_right_terminate_by_synchronous_exception
+    , testCase "left_terminate_by_synchronous_exception"
+           race_left_terminate_by_synchronous_exception
+    , testCase "right_terminates_normally_kills_left"
+           race_right_terminates_normally_kills_left
+    , testCase "left_terminates_normally_kills_right"
+           race_left_terminates_normally_kills_right
+    , testCase "right_terminates_by_asynchronous_exception_kills_both"
+           race_right_terminates_by_asynchronous_exception_kills_both
+    , testCase "left_terminates_by_asynchronous_exception_kills_right"
+           race_left_terminates_by_asynchronous_exception_kills_right
+    ]
  ]
 
 value = 42 :: Int
@@ -72,13 +103,61 @@ withasync_waitCatch = do
       Left _  -> assertFailure ""
       Right e -> e @?= value
 
-withasync_wait2 :: Assertion
-withasync_wait2 = do
+withasync_functionReturned_threadKilled :: Assertion
+withasync_functionReturned_threadKilled = do
   a <- withAsync (threadDelay 1000000) $ return
   r <- waitCatch a
   case r of
     Left e  -> fromException e @?= Just ThreadKilled
     Right _ -> assertFailure ""
+
+withasync_synchronousException_threadKilled :: Assertion
+withasync_synchronousException_threadKilled = do
+  mv <- newEmptyMVar
+  catchIgnore $ withAsync (threadDelay 1000000) $ \a -> do
+    putMVar mv a
+    throwIO DivideByZero
+  a <- takeMVar mv
+  r <- waitCatch a
+  case r of
+    Left e  -> fromException e @?= Just ThreadKilled
+    Right _ -> assertFailure ""
+
+catchIgnore :: IO a -> IO ()
+catchIgnore m = void m `catch` \(e :: SomeException) -> return ()
+
+withasync_asynchronousException_rethrown :: Assertion
+withasync_asynchronousException_rethrown = do
+  mv <- newEmptyMVar
+  catchIgnore $ withAsync (threadDelay 1000000) $ \a -> do
+    putMVar mv a
+    throwIO UserInterrupt
+  a <- takeMVar mv
+  r <- waitCatch a
+  case r of
+    Left e  -> fromException e @?= Just UserInterrupt
+    Right _ -> assertFailure ""
+
+#if MIN_VERSION_base(4,7,0)
+-- This test requires the SomeAsyncException type
+-- which is only available in base >= 4.7
+withasync_timeoutException_rethrown :: Assertion
+withasync_timeoutException_rethrown = do
+  mv <- newEmptyMVar
+  timeout 100000 $ withAsync (threadDelay 1000000) $ \a -> do
+    putMVar mv a
+    threadDelay 1000000
+  a <- takeMVar mv
+  r <- waitCatch a
+  case r of
+    Left e  -> do
+      case fromException e of
+        Nothing -> assertFailure ""
+        Just (e :: SomeAsyncException) ->
+            -- e should be a Timeout exception
+            return ()
+    Right _ -> assertFailure ""
+#endif
 
 async_cancel :: Assertion
 async_cancel = do
@@ -115,3 +194,79 @@ withasync_waitCatch_blocked = do
             Just BlockedIndefinitelyOnMVar -> return ()
             Nothing -> assertFailure $ show e
     Right () -> assertFailure ""
+
+race_right_terminate_normally :: Assertion
+race_right_terminate_normally = do
+  r <- race (threadDelay 100000 >> return 1)
+            (threadDelay 10000  >> return 'x')
+  r @?= (Right 'x')
+
+race_left_terminate_normally :: Assertion
+race_left_terminate_normally = do
+  r <- race (threadDelay 10000  >> return 1)
+            (threadDelay 100000 >> return 'x')
+  r @?= (Left 1)
+
+race_right_terminate_by_synchronous_exception :: Assertion
+race_right_terminate_by_synchronous_exception = do
+  r <- try (race (threadDelay 100000 >> return 1)
+                 (threadDelay 10000  >> throwIO DivideByZero))
+  case r of
+    Left e -> e @?= DivideByZero
+    _ -> assertFailure ""
+
+race_left_terminate_by_synchronous_exception :: Assertion
+race_left_terminate_by_synchronous_exception = do
+  r <- try (race (threadDelay 10000  >> throwIO DivideByZero)
+                 (threadDelay 100000 >> return 'x'))
+  case r of
+    Left e -> e @?= DivideByZero
+    _ -> assertFailure ""
+
+race_right_terminates_normally_kills_left :: Assertion
+race_right_terminates_normally_kills_left = do
+  ref <- newIORef False
+  r <- race (threadDelay 100000 >> writeIORef ref True)
+            (threadDelay 10000  >> return 'x')
+  leftCompleted <- readIORef ref
+  assertBool "" $ not leftCompleted && r == Right 'x'
+
+race_left_terminates_normally_kills_right :: Assertion
+race_left_terminates_normally_kills_right = do
+  ref <- newIORef False
+  r <- race (threadDelay 10000  >> return 1)
+            (threadDelay 100000 >> writeIORef ref True)
+  rightCompleted <- readIORef ref
+  assertBool "" $ not rightCompleted && r == Left 1
+
+race_right_terminates_by_asynchronous_exception_kills_both :: Assertion
+race_right_terminates_by_asynchronous_exception_kills_both = do
+  leftRef  <- newIORef False
+  rightRef <- newIORef False
+
+  timeout 1000 $
+    race (threadDelay 10000 >> writeIORef leftRef  True)
+         (threadDelay 10000 >> writeIORef rightRef True)
+
+  leftCompleted  <- readIORef leftRef
+  rightCompleted <- readIORef rightRef
+
+  assertBool "" $ not leftCompleted && not rightCompleted
+
+race_left_terminates_by_asynchronous_exception_kills_right :: Assertion
+race_left_terminates_by_asynchronous_exception_kills_right = do
+  mv <- newEmptyMVar
+
+  forkIO $ do
+    threadDelay 100000
+    leftTid <- takeMVar mv
+    throwTo leftTid ThreadKilled
+
+  r <- try $ race (do leftTid <- myThreadId
+                      putMVar mv leftTid
+                      threadDelay 1000000
+                      return 1)
+                  (do threadDelay 1000000
+                      return 'x')
+
+  r @?= Left ThreadKilled


### PR DESCRIPTION
Hi Simon,

This is an attempt to solve #5 by following your suggested approach of changing the semantics of `withAsync` such that if the inner function receives an asynchronous exception it will also be thrown to the forked action. But if it receives a synchronous action the forked action will be killed.

This change in semantics allows for an implementation of `race` and `concurrently` which only needs to fork a single thread (instead of two) which doubles performance.

I'm pretty sure that `concurrently` is correct. I'm less sure about `race` because it uses a complex implementation. Although the test cases I added for `race` seem to indicate it operates correctly.

Let me know what you think.

This patch was co-written with my colleague @asayers.
