### PR TITLE
Remove invalid instance Monad Concurrently.

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -573,11 +573,6 @@ instance Alternative Concurrently where
   Concurrently as <|> Concurrently bs =
     Concurrently $ either id id <$> race as bs
 
-instance Monad Concurrently where
-  return = pure
-  Concurrently a >>= f =
-    Concurrently $ a >>= runConcurrently . f
-
 -- ----------------------------------------------------------------------------
 
 -- | Fork a thread that runs the supplied action, and if it raises an


### PR DESCRIPTION
The `Monad` instance for `Concurrently` is invalid: we have `(<*>) /= ap` because `ap` runs the two actions sequentially while `(<*>)` runs them concurrently. There is no way to write a valid `Monad` instance for `Concurrently`, so the existing broken instance should just be removed.

The existence of an invalid `Monad` instance causes breakage in the wild. See, for example, ekmett/either#38.