### PR TITLE
Sync & failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       compiler: ": #GHC head"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
@@ -66,7 +69,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
    fi
 
 # snapshot package-db on cache miss
@@ -85,6 +88,7 @@ script:
  - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
+ - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -92,6 +92,9 @@ module Control.Concurrent.Async (
     -- ** Spawning with automatic 'cancel'ation
     withAsync, withAsyncBound, withAsyncOn, withAsyncWithUnmask, withAsyncOnWithUnmask,
 
+    -- ** Synchronous creation
+    sync, failed,
+
     -- ** Querying 'Async's
     wait, poll, waitCatch, cancel, cancelWith,
     asyncThreadId,
@@ -184,6 +187,19 @@ asyncWithUnmask actionWith = asyncUsing rawForkIO (actionWith unsafeUnmask)
 -- The child thread is passed a function that can be used to unmask asynchronous exceptions.
 asyncOnWithUnmask :: Int -> ((forall b . IO b -> IO b) -> IO a) -> IO (Async a)
 asyncOnWithUnmask cpu actionWith = asyncUsing (rawForkOn cpu) (actionWith unsafeUnmask)
+
+endedSyncThreadId :: ThreadId
+endedSyncThreadId = unsafePerformIO $ forkIO $ pure ()
+{-# NOINLINE endedSyncThreadId #-}
+
+-- | Create 'Async' value from concrete value.
+-- This saves from thread spawning when the value is already computed.
+sync :: a -> Async a
+sync = Async endedSyncThreadId . pure . Right
+
+-- | Create failed 'Async'.
+failed :: Exception e => e -> Async a
+failed = Async endedSyncThreadId . pure . Left . SomeException
 
 asyncUsing :: (IO () -> IO ThreadId)
            -> IO a -> IO (Async a)

--- a/async.cabal
+++ b/async.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 homepage:            https://github.com/simonmar/async
 bug-reports:         https://github.com/simonmar/async/issues
-tested-with:         GHC==7.11.*, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
+tested-with:         GHC==8.1.*, GHC==8.0.1, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
 
 extra-source-files:
     changelog.md


### PR DESCRIPTION
I have to admit that having `sync` might result in incorrect usage, but I had use-cases where I did:
```hs
a <- async (pure value)
```

And that felt somehow un-elegant.

I stored `Async` values in a container to be waited / cancelled later. Optionally I could have saved `(wait a, cancel a)` action pairs, but that felt a bit un-elegant as well.

If this is totally wrong, I'm happy to write a section into documentation why those functions do not exist.
