### PR TITLE
Add versions of map- and forConcurrently that discard return values

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -116,6 +116,7 @@ module Control.Concurrent.Async (
 
     -- * Convenient utilities
     race, race_, concurrently, mapConcurrently, forConcurrently,
+    mapConcurrently_, forConcurrently_,
     Concurrently(..),
 
   ) where
@@ -598,6 +599,16 @@ mapConcurrently f = runConcurrently . traverse (Concurrently . f)
 -- @since 2.1.0
 forConcurrently :: Traversable t => t a -> (a -> IO b)-> IO (t b)
 forConcurrently = flip mapConcurrently
+
+-- | `mapConcurrently_` is `mapConcurrently` with the return value discarded,
+-- just like @mapM_
+mapConcurrently_ :: Traversable t => (a -> IO b) -> t a -> IO ()
+mapConcurrently_ f t = mapConcurrently f t >> return ()
+
+-- | `forConcurrently_` is `forConcurrently` with the return value discarded,
+-- just like @forM_
+forConcurrently_ :: Traversable t => (a -> IO b) -> t a -> IO ()
+forConcurrently_ t f = forConcurrently f t >> return ()
 
 -- -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Add `mapConcurrently_` and `forConcurrently_`, which behave like `mapM_`
and `forM_` respectively in that they discard their return values and
just return `IO ()`