### PR TITLE
Some utility functions

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -630,13 +630,13 @@ forConcurrently = flip mapConcurrently
 
 -- | `mapConcurrently_` is `mapConcurrently` with the return value discarded,
 -- just like @mapM_
-mapConcurrently_ :: Traversable t => (a -> IO b) -> t a -> IO ()
-mapConcurrently_ f t = mapConcurrently f t >> return ()
+mapConcurrently_ :: F.Foldable f => (a -> IO b) -> f a -> IO ()
+mapConcurrently_ f = runConcurrently . F.foldMap (Concurrently . void . f)
 
 -- | `forConcurrently_` is `forConcurrently` with the return value discarded,
 -- just like @forM_
-forConcurrently_ :: Traversable t => t a -> (a -> IO b) -> IO ()
-forConcurrently_ t f = forConcurrently t f >> return ()
+forConcurrently_ :: F.Foldable f => f a -> (a -> IO b) -> IO ()
+forConcurrently_ = flip mapConcurrently_
 
 -- | 'concurrently', but ignore the result values
 --

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -642,8 +642,14 @@ forConcurrently_ = flip mapConcurrently_
 --
 -- @since 2.1.1
 concurrently_ :: IO a -> IO b -> IO ()
--- could consider a more optimized implementation in the future if desired
-concurrently_ left right = void (concurrently left right)
+concurrently_ left right = concurrently' left right (collect 0)
+  where
+    collect 2 _ = return ()
+    collect i m = do
+        e <- m
+        case e of
+            Left ex -> throwIO ex
+            Right _ -> collect (i + 1 :: Int) m
 
 -- | Perform the action in the given number of threads.
 --

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -115,8 +115,11 @@ module Control.Concurrent.Async (
     link, link2,
 
     -- * Convenient utilities
-    race, race_, concurrently, mapConcurrently, forConcurrently,
+    race, race_,
+    concurrently, concurrently_,
+    mapConcurrently, forConcurrently,
     mapConcurrently_, forConcurrently_,
+    replicateConcurrently, replicateConcurrently_,
     Concurrently(..),
 
   ) where
@@ -124,6 +127,7 @@ module Control.Concurrent.Async (
 import Control.Concurrent.STM
 import Control.Exception
 import Control.Concurrent
+import qualified Data.Foldable as F
 #if !MIN_VERSION_base(4,6,0)
 import Prelude hiding (catch)
 #endif
@@ -633,6 +637,25 @@ mapConcurrently_ f t = mapConcurrently f t >> return ()
 -- just like @forM_
 forConcurrently_ :: Traversable t => (a -> IO b) -> t a -> IO ()
 forConcurrently_ t f = forConcurrently f t >> return ()
+
+-- | 'concurrently', but ignore the result values
+--
+-- @since 2.1.1
+concurrently_ :: IO a -> IO b -> IO ()
+-- could consider a more optimized implementation in the future if desired
+concurrently_ left right = void (concurrently left right)
+
+-- | Perform the action in the given number of threads.
+--
+-- @since 2.1.1
+replicateConcurrently :: Int -> IO a -> IO [a]
+replicateConcurrently cnt = runConcurrently . sequenceA . replicate cnt . Concurrently
+
+-- | Same as 'replicateConcurrently', but ignore the results.
+--
+-- @since 2.1.1
+replicateConcurrently_ :: Int -> IO a -> IO ()
+replicateConcurrently_ cnt = runConcurrently . F.fold . replicate cnt . Concurrently . void
 
 -- -----------------------------------------------------------------------------
 

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -635,8 +635,8 @@ mapConcurrently_ f t = mapConcurrently f t >> return ()
 
 -- | `forConcurrently_` is `forConcurrently` with the return value discarded,
 -- just like @forM_
-forConcurrently_ :: Traversable t => (a -> IO b) -> t a -> IO ()
-forConcurrently_ t f = forConcurrently f t >> return ()
+forConcurrently_ :: Traversable t => t a -> (a -> IO b) -> IO ()
+forConcurrently_ t f = forConcurrently t f >> return ()
 
 -- | 'concurrently', but ignore the result values
 --

--- a/async.cabal
+++ b/async.cabal
@@ -1,5 +1,5 @@
 name:                async
-version:             2.1.0
+version:             2.1.1
 -- don't forget to update ./changelog.md!
 synopsis:            Run IO operations asynchronously and wait for their results
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
  - Add `concurrently_`
  - Add `replicateConcurrently`
  - Add `replicateConcurrently_`
+ - Fix incorrect argument order in `forConcurrently_`
 
 ## Changes in 2.1.0:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Changes in 2.1.1:
+
+ - Add `concurrently_`
+ - Add `replicateConcurrently`
+ - Add `replicateConcurrently_`
+
 ## Changes in 2.1.0:
 
  - Bump base dependency to allow 4.10

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
  - Add `replicateConcurrently`
  - Add `replicateConcurrently_`
  - Fix incorrect argument order in `forConcurrently_`
+ - Generalize `mapConcurrently_` and `forConcurrently_` to `Foldable`
 
 ## Changes in 2.1.0:
 


### PR DESCRIPTION
Adds `concurrently_`, `replicateConcurrently`, and `replicateConcurrently_`. Also generalizes `mapConcurrently_` and `forConcurrently_` to `Foldable`, and fixes the incorrect argument ordering for `forConcurrently_`. (That last one is technically a breaking change, but I'd argue that the previous ordering was just a bug, and I'd be surprised if anyone is using it. Also, it seems like that function may not even be released yet anyway.)