### PR TITLE
Make it build with ghc 8.2

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -50,14 +50,14 @@ library
     if impl(ghc>=7.1)
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
-    build-depends:       base >= 4.3 && < 4.10, stm >= 2.2 && < 2.5
+    build-depends:       base >= 4.3 && < 4.11, stm >= 2.2 && < 2.5
 
 test-suite test-async
     default-language: Haskell2010
     type:       exitcode-stdio-1.0
     hs-source-dirs: test
     main-is:    test-async.hs
-    build-depends: base >= 4.3 && < 4.10,
+    build-depends: base >= 4.3 && < 4.11,
                    async,
                    test-framework,
                    test-framework-hunit,


### PR DESCRIPTION
With this patch, and [this version](https://github.com/erikd/test-framework) of `test-framework` async builds with ghc-8.2.0-rc1.