### PR TITLE
Add a Hashable instance for Async

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -149,6 +149,7 @@ import Data.Typeable
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup((<>)))
 #endif
+import Data.Hashable (Hashable(hashWithSalt))
 
 import Data.IORef
 
@@ -177,6 +178,9 @@ instance Eq (Async a) where
 
 instance Ord (Async a) where
   Async a _ `compare` Async b _  =  a `compare` b
+
+instance Hashable (Async a) where
+  hashWithSalt salt (Async a _) = hashWithSalt salt a
 
 instance Functor Async where
   fmap f (Async a w) = Async a (fmap (fmap f) w)

--- a/async.cabal
+++ b/async.cabal
@@ -50,7 +50,7 @@ library
     if impl(ghc>=7.1)
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
-    build-depends:       base >= 4.3 && < 4.12, stm >= 2.2 && < 2.5
+    build-depends:       base >= 4.3 && < 4.12, hashable >= 1.1.1.0 && < 1.3, stm >= 2.2 && < 2.5
 
 test-suite test-async
     default-language: Haskell2010

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
    of ignoring AsyncCancelled.
  - new utility function compareAsyncs for comparing Asyncs of
    different types.
+ - Add a `Hashable` instance for `Async a`
 
 ## Changes in 2.1.1.1:
  - Make 'cancelWith' wait for the cancelled thread to terminate, like 'cancel'


### PR DESCRIPTION
Closes #73.

* 1.1.1.0 is the first version of `hashable` that provides the instance for `ThreadId` (and already has the modern class definition). The upper bound is just the next major version.
* I could not figure out if there was some structure in the import list, so I simply added the new import to the end. Please, let me know if there was some structure that I failed to recognise.