### PR TITLE
Document exception behavior of mapConcurrently

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -736,6 +736,9 @@ concurrently' left right collect = do
 -- the original data structure with the arguments replaced by the
 -- results.
 --
+-- If any of the actions throw an exception, then all other actions are
+-- cancelled and the exception is re-thrown.
+--
 -- For example, @mapConcurrently@ works with lists:
 --
 -- > pages <- mapConcurrently getURL ["url1", "url2", "url3"]


### PR DESCRIPTION
You have to re-throw the exceptions, there's nothing else you can do about it, but what happens to other threads are not clear, you have to see the source code (steps I had to take: realize that it uses `Concurrently` under the hood, check its `Applicative` implementation, see that it uses `concurrently`, check `concurrently`).