### PR TITLE
Fixed compilation with GHC 8.6.1-alpha2

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -50,14 +50,14 @@ library
     if impl(ghc>=7.1)
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
-    build-depends:       base >= 4.3 && < 4.12, hashable >= 1.1.1.0 && < 1.3, stm >= 2.2 && < 2.5
+    build-depends:       base >= 4.3 && < 4.13, hashable >= 1.1.1.0 && < 1.3, stm >= 2.2 && < 2.6
 
 test-suite test-async
     default-language: Haskell2010
     type:       exitcode-stdio-1.0
     hs-source-dirs: test
     main-is:    test-async.hs
-    build-depends: base >= 4.3 && < 4.12,
+    build-depends: base >= 4.3 && < 4.13,
                    async,
                    stm,
                    test-framework,


### PR DESCRIPTION
GHC 8.6.1-alpha2 was [announced](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-July/026776.html). This PR fix the compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/3160.