### PR TITLE
Fix withAsync documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 *~
 .stack-work/
+*.hi
+*.o

--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -230,7 +230,7 @@ asyncUsing doFork = \action -> do
 --
 -- > withAsync action inner = mask $ \restore -> do
 -- >   a <- async (restore action)
--- >   restore inner `finally` uninterruptibleCancel a
+-- >   restore (inner a) `finally` uninterruptibleCancel a
 --
 -- This is a useful variant of 'async' that ensures an @Async@ is
 -- never left running unintentionally.


### PR DESCRIPTION
The `withAsync` documentation didn't typecheck. Fix that.