### PR TITLE
Bump base bounds

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -50,14 +50,14 @@ library
     if impl(ghc>=7.1)
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
-    build-depends:       base >= 4.3 && < 4.13, hashable >= 1.1.1.0 && < 1.3, stm >= 2.2 && < 2.6
+    build-depends:       base >= 4.3 && < 4.14, hashable >= 1.1.1.0 && < 1.3, stm >= 2.2 && < 2.6
 
 test-suite test-async
     default-language: Haskell2010
     type:       exitcode-stdio-1.0
     hs-source-dirs: test
     main-is:    test-async.hs
-    build-depends: base >= 4.3 && < 4.13,
+    build-depends: base >= 4.3 && < 4.14,
                    async,
                    stm,
                    test-framework,


### PR DESCRIPTION
This allows `async` to be used and tested with with GHC 8.8.1