### PR TITLE
Improve ExceptionInLinkedThread Show instance

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -540,8 +540,12 @@ data ExceptionInLinkedThread =
 #endif
 
 instance Show ExceptionInLinkedThread where
-  show (ExceptionInLinkedThread (Async t _) e) =
-    "ExceptionInLinkedThread " ++ show t ++ " " ++ show e
+  showsPrec p (ExceptionInLinkedThread (Async t _) e) =
+    showParen (p >= 11) $
+      showString "ExceptionInLinkedThread " .
+      showsPrec 11 t .
+      showString " " .
+      showsPrec 11 e
 
 instance Exception ExceptionInLinkedThread where
 #if __GLASGOW_HASKELL__ >= 708


### PR DESCRIPTION
By implementing it using `showsPrec` instead of `show`, so that it
will optionally insert parentheses. Here's an example

```haskell
    import Control.Concurrent.Async
    import Control.Concurrent
    import Control.Exception

    main :: IO ()
    main = do
      let oneSecond = 1000000
      a <- async $ do
        a <- async $ do
          evaluate $ 1 `div` 0
          return ()
        link a
        threadDelay oneSecond
        wait a
      link a
      threadDelay oneSecond
      wait a
```

Running this program produces

    ./Test
    Test: ExceptionInLinkedThread ThreadId 2 ExceptionInLinkedThread ThreadId 4 divide by zero

But with the change in the current commit, and some related GHC
PRs (https://github.com/ghc/ghc/pull/254, https://github.com/ghc/ghc/pull/253), it should produce

    ./Test
    Test: ExceptionInLinkedThread (ThreadId 2) (ExceptionInLinkedThread (ThreadId 4) divide by zero)

instead.