### PR TITLE
docs: Explain more clearly that `withAsync` should be preferred over `async`

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -82,6 +82,12 @@
 -- >       (page1, page2) <- concurrently (getURL url1) (getURL url2)
 -- >       ...
 --
+-- If you need to wait for /N/ results, or for only one of multiple
+-- results, or a combination of those, see the section __/Convenient utilities/__.
+--
+-- In general,
+-- __most practical production code should only use the functions from the /Convenient utilities/ section__.
+--
 -- The 'Functor' instance can be used to change the result of an
 -- 'Async'.  For example:
 --


### PR DESCRIPTION
Over the last 5 years I have seen way too many people use `async` incorrectly because they do not read or remember the tutorial, and the temptation is large to copy-paste the first code example that appears in the documentation (some might say that is unconvientional/surprising to have the first code example be not-production-ready).

Also, it is unintuitive to beginners that the function `async` (after which the package is even named) is the function they should _avoid_ in practice, so it deserves an extra comment.

The first commit makes the documentation more explicit, and also does away with the "slight improvement" terminology on the code that is absolutely necessary to write non-leaking production code.

The second commit also makes it explicit that for most production code you likely want to use the high-level functions.