### PR TITLE
Travis: Remove GHC 7.0.4 and lts-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.0.4"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.2.2"
     addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -76,10 +73,6 @@ matrix:
   # variable, such as using --stack-yaml to point to a different file.
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
-    addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
     addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-3"


### PR DESCRIPTION
These two have started failing.

GHC 7.0.4 fails with

    Preprocessing library text-1.2.4.0...
    target `' is not a module name or a source file
    Failed to install text-1.2.4.0

lts-2 fails with

    Stack no longer supports Cabal versions older than 1.19.2, but version
    1.18.1.5 was found.  To fix this, consider updating the resolver to
    lts-3.0 or later / nightly-2015-05-05 or later.

I don't know how to fix either of these so I'll just disable them.