### PR TITLE
Allow base-4.14 (GHC-8.10)

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 homepage:            https://github.com/simonmar/async
 bug-reports:         https://github.com/simonmar/async/issues
-tested-with:         GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
+tested-with:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
 
 extra-source-files:
     changelog.md
@@ -50,14 +50,14 @@ library
     if impl(ghc>=7.1)
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
-    build-depends:       base >= 4.3 && < 4.14, hashable >= 1.1.2.0 && < 1.4, stm >= 2.2 && < 2.6
+    build-depends:       base >= 4.3 && < 4.15, hashable >= 1.1.2.0 && < 1.4, stm >= 2.2 && < 2.6
 
 test-suite test-async
     default-language: Haskell2010
     type:       exitcode-stdio-1.0
     hs-source-dirs: test
     main-is:    test-async.hs
-    build-depends: base >= 4.3 && < 4.14,
+    build-depends: base >= 4.3 && < 4.15,
                    async,
                    stm,
                    test-framework,


### PR DESCRIPTION
I haven't added jobs to travis matrix, as cabal-install-3.0 and
cabal-install-3.2 changed build to be v2-build.

Script might need some rewrite.