### PR TITLE
Document that empty for Concurrently waits forever.

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -910,6 +910,7 @@ instance Applicative Concurrently where
   Concurrently fs <*> Concurrently as =
     Concurrently $ (\(f, a) -> f a) <$> concurrently fs as
 
+-- | 'Control.Alternative.empty' waits forever. 'Control.Alternative.<|>' returns the first to finish and 'cancel's the other.
 instance Alternative Concurrently where
   empty = Concurrently $ forever (threadDelay maxBound)
   Concurrently as <|> Concurrently bs =


### PR DESCRIPTION
The Haddocks don't spell out that `empty` for Concurrently is an action that waits forever. I added it to the 'Alternative' instance.