### PR TITLE
Change example for "thread leak" to better one

### DIFF
--- a/Control/Concurrent/Async.hs
+++ b/Control/Concurrent/Async.hs
@@ -117,7 +117,7 @@
 -- >
 -- >   putStrLn "hello from main thread"
 -- >   threadDelay (2 * one_second)
--- >   wait a -- will throw MyException
+-- >   wait a -- will throw MyException, program will terminate
 -- >   where
 -- >     one_second = 10^6
 --


### PR DESCRIPTION
this example helped me to reproduce what is "thread leak", old example is misleading because suggests that could be reproduced from main thread, but it's not