### PR TITLE
Allow disabling hashable dependency

### DIFF
--- a/Control/Concurrent/Async/Internal.hs
+++ b/Control/Concurrent/Async/Internal.hs
@@ -49,7 +49,9 @@ import Data.Bifunctor
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup((<>)))
 #endif
+#ifdef HASHABLE
 import Data.Hashable (Hashable(hashWithSalt))
+#endif
 
 import Data.IORef
 
@@ -79,8 +81,10 @@ instance Eq (Async a) where
 instance Ord (Async a) where
   Async a _ `compare` Async b _  =  a `compare` b
 
+#ifdef HASHABLE
 instance Hashable (Async a) where
   hashWithSalt salt (Async a _) = hashWithSalt salt a
+#endif
 
 instance Functor Async where
   fmap f (Async a w) = Async a (fmap (fmap f) w)

--- a/async.cabal
+++ b/async.cabal
@@ -62,6 +62,11 @@ source-repository head
     type: git
     location: https://github.com/simonmar/async.git
 
+flag hashable
+    description: Enabled the `Hashable (Async a)` instance, and the `hashable` dependency.
+    manual: True
+    default: True
+
 library
     default-language:    Haskell2010
     other-extensions:    CPP, MagicHash, RankNTypes, UnboxedTuples
@@ -70,8 +75,10 @@ library
     exposed-modules:     Control.Concurrent.Async
                          Control.Concurrent.Async.Internal
     build-depends:       base     >= 4.3     && < 4.20,
-                         hashable >= 1.1.2.0 && < 1.5,
                          stm      >= 2.2     && < 2.6
+    if flag(hashable)
+                         cpp-options: -DHASHABLE
+                         build-depends: hashable >= 1.1.2.0 && < 1.5
 
 test-suite test-async
     default-language: Haskell2010


### PR DESCRIPTION
This allows people to disable the Hashable instance, and dependency.
To keep compatibility, it's implemented as a flag that defaults to true.
I think that if async were to release a new major version, it would be good to implement this as a sublibrary instead.