### PR TITLE
bump hashable upper bound <1.6

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -71,7 +71,7 @@ library
     exposed-modules:     Control.Concurrent.Async
                          Control.Concurrent.Async.Internal
     build-depends:       base     >= 4.3     && < 4.21,
-                         hashable >= 1.1.2.0 && < 1.5,
+                         hashable >= 1.1.2.0 && < 1.6,
                          stm      >= 2.2     && < 2.6
 
 test-suite test-async


### PR DESCRIPTION
Latest hashable released version is 1.5.0.0. async builds on my end with this new release. Here are the upstream changes for this release:

---

- Add QuantifiedConstraints superclasses to Hashable1/2:

```haskell
class (Eq1 t, forall a. Hashable a => Hashable (t a)) => Hashable1 t where
class (Eq2 t, forall a. Hashable a => Hashable1 (t a)) => Hashable2 t where
```

- Change contexts of Compose, Product and Sum instances. This and above is the similar change as CLC proposal 10

- The above changes require base-4.18.0.0, so we drop support for GHC prior GHC-9.6.5 (The hashable-1.4 branch will be maintained for time being for older GHC users).

- Make Arg a b instance behave as Hashable a instance.

---

Resolves #157 and build issues on my end when scientific-0.3.8.0 and tls-2.1.0 are involved (both latest transitive dependency of a http-conduit library installation) 