### PR TITLE
Support ghc-9.12

### DIFF
--- a/async.cabal
+++ b/async.cabal
@@ -70,7 +70,7 @@ library
         other-extensions: Trustworthy
     exposed-modules:     Control.Concurrent.Async
                          Control.Concurrent.Async.Internal
-    build-depends:       base     >= 4.3     && < 4.21,
+    build-depends:       base     >= 4.3     && < 4.22,
                          hashable >= 1.1.2.0 && < 1.6,
                          stm      >= 2.2     && < 2.6
 


### PR DESCRIPTION
Only needed to bump the `base` dependency.

Needed to add a `cabal.project.local` file containing:
```
allow-newer:
  , hashable:base
```
The issue for [hashable](https://github.com/haskell-unordered-containers/hashable/issues/312).