### PR TITLE
Support GHC 9.14.1, base-4.22, and regenerate CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20260102
+# version: 0.19.20260104
 #
-# REGENDATA ("0.19.20260102",["github","async.cabal"])
+# REGENDATA ("0.19.20260104",["github","async.cabal"])
 #
 name: Haskell-CI
 on:
@@ -35,6 +35,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2

--- a/async.cabal
+++ b/async.cabal
@@ -35,6 +35,7 @@ cabal-version:       >=1.10
 homepage:            https://github.com/simonmar/async
 bug-reports:         https://github.com/simonmar/async/issues
 tested-with:
+    GHC == 9.14.1
     GHC == 9.12.2
     GHC == 9.10.2
     GHC == 9.8.4
@@ -83,7 +84,7 @@ library
                          Control.Concurrent.Async.Internal
                          Control.Concurrent.Async.Warden
                          Control.Concurrent.Stream
-    build-depends:       base     >= 4.3     && < 4.22,
+    build-depends:       base     >= 4.3     && < 4.23,
                          hashable >= 1.1.2.0 && < 1.6,
                          stm      >= 2.2     && < 2.6,
                          unordered-containers >= 0.2 && < 0.3


### PR DESCRIPTION
Per CI in [my own fork](https://github.com/bmillwood/async/pull/1) it doesn't seem like any changes are necessary, but I admit I didn't read the changelogs carefully.

base changelog: https://hackage.haskell.org/package/base-4.22.0.0/changelog

- Resolves #175 