### PR TITLE
Warden: Don't spawn new threads when canceling

### DIFF
--- a/Control/Concurrent/Async/Warden.hs
+++ b/Control/Concurrent/Async/Warden.hs
@@ -62,7 +62,7 @@ create = Warden <$> newMVar (Just mempty)
 shutdown :: Warden -> IO ()
 shutdown (Warden v) = do
   r <- swapMVar v Nothing
-  mapM_ (Async.mapConcurrently_ Async.cancel) r
+  mapM_ (Async.cancelMany . HashSet.toList) r
 
 forget :: Warden -> Async a -> IO ()
 forget (Warden v) async = modifyMVar_ v $ \x -> case x of


### PR DESCRIPTION
This now:
- throws `AsyncCancelled` to each remaining job (from the current thread, without spawning any new threads)
- waits for each job to terminate

@simonmar from what I understand, the existing code spawns a new thread for each remaining job in the cancel queue.  I'm not claiming that this is necessarily a big problem or even observable in many situations, I didn't run anything, this is purely from reading the code. BUT: The existing code also requires you to read much more code if you wanna understand what exactly is happening.

So unless I'm missing some nuance here, the new code should be both:
- more resource efficient
- easier to understand