### PR TITLE
Fix documentation of `Control.Concurrent.Async.Warden.shutdown`

### DIFF
--- a/Control/Concurrent/Async/Warden.hs
+++ b/Control/Concurrent/Async/Warden.hs
@@ -54,10 +54,11 @@ create :: IO Warden
 create = Warden <$> newMVar (Just mempty)
 
 -- | Shutdown a 'Warden', calling 'cancel' on all owned threads. Subsequent
--- calls to 'spawn' and 'shutdown' will be no-ops. 
--- 
+-- calls to 'spawn' will throw `WardenException`.  Subsequent calls to
+-- 'shutdown' will be a no-op.
+--
 -- Note that any exceptions thrown by the threads will be ignored. If you want
--- exceptions to be propagated, either call `wait` explicitly on the 'Async', 
+-- exceptions to be propagated, either call `wait` explicitly on the 'Async',
 -- or use 'link'.
 shutdown :: Warden -> IO ()
 shutdown (Warden v) = do


### PR DESCRIPTION
I changed the documentation to what the current code does.

However, personally, I think I would prefer the documented behavior:

- Provided you use `withWarden`, misusing this takes such deliberate effort that I'm not convinced it's worth protecting against it.
- Going with the documented behavior:
  - keeps the documentation (and by extension behavior) simpler
  - allows you to remove `WardenException` entirely